### PR TITLE
GitHub Dependency Graph fix

### DIFF
--- a/.gitattribute
+++ b/.gitattribute
@@ -1,0 +1,2 @@
+css/*  linguist-vendored
+pages.css linguist-vendored=false


### PR DESCRIPTION
GitHub Dependency Graph has identified your repo as the original source of MDL, which isn't the case. This will fix that.